### PR TITLE
Applied changes for Spring-Boot 2.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '1.5.10.RELEASE'
+		springBootVersion = '2.0.1.RELEASE'
 	}
 	repositories {
 		mavenCentral()
@@ -12,8 +12,9 @@ buildscript {
 
 apply plugin: 'groovy'
 apply plugin: 'org.springframework.boot'
+apply plugin: 'io.spring.dependency-management'
 
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-SNAPSHOT'
 sourceCompatibility = 1.8
 
 repositories {

--- a/src/test/groovy/com/groovycoder/groovyintegrationtesting/MongoSpecification.groovy
+++ b/src/test/groovy/com/groovycoder/groovyintegrationtesting/MongoSpecification.groovy
@@ -2,7 +2,7 @@ package com.groovycoder.groovyintegrationtesting
 
 import com.groovycoder.spockdockerextension.Testcontainers
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.util.EnvironmentTestUtils
+import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.test.annotation.DirtiesContext
@@ -40,13 +40,14 @@ abstract class MongoSpecification extends Specification {
     static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
         @Override
         void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-            EnvironmentTestUtils.addEnvironment("testcontainers", configurableApplicationContext.getEnvironment(),
+            TestPropertyValues values = TestPropertyValues.of(
                     "spring.data.mongodb.host=" + staticContainerHandle.containerIpAddress,
                     "spring.data.mongodb.port=" + staticContainerHandle.getMappedPort(27017),
                     "spring.datasource.url=" + staticPostgresContainerHandle.jdbcUrl,
                     "spring.datasource.username=" + staticPostgresContainerHandle.username,
                     "spring.datasource.password=" + staticPostgresContainerHandle.password,
             )
+            values.applyTo(configurableApplicationContext)
         }
     }
 

--- a/src/test/groovy/com/groovycoder/groovyintegrationtesting/MongoTests.groovy
+++ b/src/test/groovy/com/groovycoder/groovyintegrationtesting/MongoTests.groovy
@@ -21,7 +21,7 @@ class MongoTests extends MongoSpecification {
         def customers = [alice, bob]
 
         when: "saving them"
-        repository.save(customers)
+        repository.saveAll(customers)
 
         then: "an id is assigned"
         customers*.id != null

--- a/src/test/groovy/com/groovycoder/groovyintegrationtesting/SharedDatabaseSpecification.groovy
+++ b/src/test/groovy/com/groovycoder/groovyintegrationtesting/SharedDatabaseSpecification.groovy
@@ -2,7 +2,7 @@ package com.groovycoder.groovyintegrationtesting
 
 import com.groovycoder.spockdockerextension.Testcontainers
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.util.EnvironmentTestUtils
+import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.test.annotation.DirtiesContext
@@ -32,11 +32,12 @@ abstract class SharedDatabaseSpecification extends Specification {
     static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
         @Override
         void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-            EnvironmentTestUtils.addEnvironment("testcontainers", configurableApplicationContext.getEnvironment(),
+            TestPropertyValues values = TestPropertyValues.of(
                     "spring.datasource.url=" + staticContainerHandle.jdbcUrl,
                     "spring.datasource.username=" + staticContainerHandle.username,
                     "spring.datasource.password=" + staticContainerHandle.password,
             )
+            values.applyTo(configurableApplicationContext)
         }
     }
 


### PR DESCRIPTION
Did necessary changes for Spring-Boot version 2.0.1.

It needed some changes in the build.gradle but also some changes for the Abstract-Classes which initialize the staticContainerHandles. The usage of EnvironmentTestUtils is deprecated. I've changed it to TestPropertyValues.